### PR TITLE
[CYL-2746] Added ability to change system locale to TestButler API.

### DIFF
--- a/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-app/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -27,4 +27,6 @@ interface ButlerApi {
      * Param should be one of Surface.ROTATION_X
      */
     boolean setRotation(int rotation);
+
+    boolean setSystemLocale(String language, String country);
 }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/ButlerService.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static android.provider.Settings.Secure.LOCATION_MODE;
+import static android.provider.Settings.System.USER_ROTATION;
 
 /**
  * Main entry point into the Test Butler application.
@@ -64,6 +65,7 @@ public class ButlerService extends IntentService {
     private boolean restoreLocationMode = true;
     private boolean restoreAnimations = true;
     private boolean restoreSystemLocale = true;
+    private boolean restoreRotation = true;
 
     private final ButlerApi.Stub butlerApi = new ButlerApi.Stub() {
         @Override
@@ -160,7 +162,8 @@ public class ButlerService extends IntentService {
             systemLocaleChanger.setSystemLocale(systemLocale);
 
         // Reset rotation from the accelerometer to whatever it originally was
-        rotationChanger.restoreRotationState(getContentResolver());
+        if(restoreRotation)
+            rotationChanger.restoreRotationState(getContentResolver());
 
         // Uninstall our IActivityController to resume normal Activity behavior
         NoDialogActivityController.uninstall();
@@ -200,6 +203,13 @@ public class ButlerService extends IntentService {
                         }
                         restoreSystemLocale = false;
                         break;
+                    case USER_ROTATION:
+                        try {
+                            butlerApi.setRotation(extras.getInt(USER_ROTATION));
+                        } catch (RemoteException e) {
+                            e.printStackTrace();
+                        }
+                        restoreRotation = false;
                     default:
                 }
             }

--- a/test-butler-app/src/main/java/com/linkedin/android/testbutler/SystemLocaleChanger.java
+++ b/test-butler-app/src/main/java/com/linkedin/android/testbutler/SystemLocaleChanger.java
@@ -1,0 +1,24 @@
+package com.linkedin.android.testbutler;
+
+import java.util.Locale;
+
+class SystemLocaleChanger {
+    boolean setSystemLocale(String language, String country) {
+        return setSystemLocale(new Locale(language, country));
+    }
+
+    boolean setSystemLocale(Locale locale) {
+        try {
+            Class<?> activityManagerNative = Class.forName("android.app.ActivityManagerNative");
+            Object am = activityManagerNative.getMethod("getDefault").invoke(activityManagerNative);
+            Object config = am.getClass().getMethod("getConfiguration").invoke(am);
+            config.getClass().getDeclaredField("locale").set(config, locale);
+            config.getClass().getDeclaredField("userSetLocale").setBoolean(config, true);
+            am.getClass().getMethod("updateConfiguration", android.content.res.Configuration.class).invoke(am, config);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
+++ b/test-butler-library/src/main/aidl/com/linkedin/android/testbutler/ButlerApi.aidl
@@ -27,4 +27,6 @@ interface ButlerApi {
      * Param should be one of Surface.ROTATION_X
      */
     boolean setRotation(int rotation);
+
+    boolean setSystemLocale(String language, String country);
 }

--- a/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
+++ b/test-butler-library/src/main/java/com/linkedin/android/testbutler/TestButler.java
@@ -200,6 +200,24 @@ public class TestButler {
     }
 
     /**
+     * Set the system locale for the device. This is useful if the tests require using external
+     * apps in the same language or if the current locale from the {@link Configuration} is not honored.
+     *
+     * @param language the language code for the new locale, as expected by {@link Locale#Locale(String, String)}
+     * @param country  the country code for the new locale, as expected by {@link Locale#Locale(String, String)}
+     */
+    public static void setSystemLocale(@NonNull String language, @NonNull String country) {
+        verifyApiReady();
+        try {
+            if (!butlerApi.setSystemLocale(language, country)) {
+                throw new IllegalStateException("Failed to set system locale!");
+            }
+        } catch (RemoteException e) {
+            throw new IllegalStateException("Failed to communicate with ButlerService", e);
+        }
+    }
+
+    /**
      * Change the screen rotation of the emulator
      *
      * @param rotation one of the {@link Rotation} IntDef values


### PR DESCRIPTION
This is useful for tests using apps that do not honor the configuration changes made by the existing locale setting approach
and also useful for setting the locale from ADB to be used in other testing frameworks.

The broadcast receiver for the Test Butler App can accept a command like so to change the locale:

``` sh
adb shell am broadcast -n com.linkedin.android.testbutler/.ButlerReceiver --es system_locale en-US
```

where the format of the extra matches the regex "[a-zA-Z]{2}-[a-zA-Z]{2}" which is the format `Locale.toLanguageTag()` returns.

Reviewer: @bpenrod 
